### PR TITLE
Include missing varargs in cache key

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,4 @@ jab (Joshua Bronson)
 kennethreitz (Kenneth Reitz)
 Thomas Waldmann
 tvavrys (Tom Vavrys)
+patgmiller (Patrick Miller)

--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -271,6 +271,11 @@ class Memoizer(object):
 
             new_args.append(arg)
 
+        # If there are any missing varargs then
+        # just append them since consistency of the key trumps order.
+        if argspec.varargs and args_len < len(args):
+            new_args.extend(args[args_len:])
+
         return tuple(new_args), kwargs
 
     def memoize(self, timeout=DEFAULT_TIMEOUT, make_name=None, unless=None):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 
 setup(
     name='django-memoize',
-    version='1.2.0',
+    version='1.2.1b',
     packages=['memoize'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Here is a potential solution to the issue I mentioned earlier today, in which `varargs` are not included in the cache key and so in some cases a different should be returned but the cached version is returned instead.  