### PR TITLE
Added handling of None values in cache

### DIFF
--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -92,7 +92,7 @@ class Memoizer(object):
 
     def get(self, key):
         "Proxy function for internal cache object."
-        return self.cache.get(key=key)
+        return self.cache.get(key=key, default='memoize:no_key')
 
     def set(self, key, value, timeout=DEFAULT_TIMEOUT):
         "Proxy function for internal cache object."
@@ -354,7 +354,7 @@ class Memoizer(object):
                     )
                     return f(*args, **kwargs)
 
-                if rv is None:
+                if rv == 'memoize:no_key':
                     rv = f(*args, **kwargs)
                     try:
                         self.set(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -32,7 +32,7 @@ class MemoizeTestCase(SimpleTestCase):
 
         self.memoizer.delete('hi')
 
-        assert self.memoizer.get('hi') is None
+        assert self.memoizer.get('hi') == 'memoize:no_key'
 
     def test_06_memoize(self):
         @self.memoizer.memoize(5)
@@ -106,7 +106,7 @@ class MemoizeTestCase(SimpleTestCase):
 
         _fname, _fname_instance = function_namespace(big_foo)
         version_key = self.memoizer._memvname(_fname)
-        assert self.memoizer.get(version_key) is None
+        assert self.memoizer.get(version_key) == 'memoize:no_key'
 
         assert big_foo(5, 2) != result
         assert big_foo(5, 3) != result2


### PR DESCRIPTION
This adds handling of `None` values. Use case is:

Sample memoized function like:

```
   @memoize(timeout=100)
   def sample(param):
       return Model.objects.filter(field=param).first()
```

In case `sample` function returns `None` this `None` is stored in the cache by memoize. However in case of further calls to the `sample` function, memoize internally does `rv = self.get(...)` and then `if rv is None: then execute function again`. This means it treats `None` as no value in cache. Provided fix changes this behaviour to clearly differentiate between "no value in cache" and "`None` in cache" situations.
