### PR TITLE
Variable timeout

### DIFF
--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -359,6 +359,7 @@ class Memoizer(object):
                         else:
                             final_timeout = decorated_function.cache_timeout
 
+                        logger.debug('Timeout set to: %.2f sec' % final_timeout)
                         self.set(
                             cache_key, rv,
                             timeout=final_timeout

--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -7,6 +7,7 @@ import hashlib
 import inspect
 import logging
 import uuid
+import time
 
 from django.conf import settings
 from django.core.cache import cache as default_cache
@@ -14,6 +15,20 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.utils.encoding import force_bytes
 
 logger = logging.getLogger(__name__)
+
+
+# From: http://preshing.com/20110924/timing-your-code-using-pythons-with-statement/
+class _TimeCounter(object):
+    def __init__(self, measurer=None):
+        self.measurer = measurer or time.time
+
+    def __enter__(self):
+        self.start = self.measurer()
+        return self
+
+    def __exit__(self, *args):
+        self.end = self.measurer()
+        self.interval = self.end - self.start
 
 
 def function_namespace(f, args=None):


### PR DESCRIPTION
`memoise()` now accepts a `timeout_function(time_spent)` argument that can vary the timeout based on how much it costed to call the real function. For exemple: `timeout_function=lambda x: 2*x` sets the timeout as the double of the time spent on the actual call.

It have a bigger priority than the `timeout` existing argument.
