### PR TITLE
Support memoizing None return value

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@ kennethreitz (Kenneth Reitz)
 Thomas Waldmann
 tvavrys (Tom Vavrys)
 patgmiller (Patrick Miller)
+brechin (Jason Brechin)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -461,3 +461,21 @@ class MemoizeTestCase(SimpleTestCase):
         args, kwargs = self.memoizer._memoize_kwargs_to_args(
             big_foo, 1, 2, d='bar', c='foo')
         assert (args == expected)
+
+    def test_17_memoize_none_value(self):
+        from memoize import DefaultCacheObject
+        self.memoizer = Memoizer(memoize_none_values=True)
+
+        @self.memoizer.memoize()
+        def foo():
+            return None
+
+        cache_key = foo.make_cache_key(foo.uncached)
+        assert isinstance(self.memoizer.get(cache_key), DefaultCacheObject)
+        result = foo()
+        assert result is None
+        assert self.memoizer.get(cache_key) is None
+
+        self.memoizer.delete_memoized(foo)
+        cache_key = foo.make_cache_key(foo.uncached)
+        assert isinstance(self.memoizer.get(cache_key), DefaultCacheObject)


### PR DESCRIPTION
There are cases where the return value of a function is `None` and can/should be cached as such.

This preserves the existing behavior of returning `None` from a `memoizer.get` (and not caching None return values) unless the user has chosen to memoize `None` values by instantiating `Memoize` with `memoize_none_values=True`.

I believe that the default for this arg could be changed to `True`, as the only case where users would be affected is if they are accessing `memoizer.get` directly.