### PR TITLE
check identity for default_cache_value

### DIFF
--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -350,7 +350,7 @@ class Memoizer(object):
                     )
                     return f(*args, **kwargs)
 
-                if rv == self.default_cache_value:
+                if rv is self.default_cache_value:
                     rv = f(*args, **kwargs)
                     try:
                         self.set(


### PR DESCRIPTION
We should use object identity instead of equality because some libraries (like pandas) returns object that overrides `__eq__` and returns non-boolean result.