### PR TITLE
Replace getargspec with getfullargspec

### DIFF
--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -7,6 +7,7 @@ import hashlib
 import inspect
 import logging
 import uuid
+import sys
 
 from django.conf import settings
 from django.core.cache import cache as default_cache
@@ -24,12 +25,16 @@ DEFAULT_CACHE_OBJECT = DefaultCacheObject()
 
 
 def _get_argspec(f):
-    try:
-        argspec = inspect.getargspec(f)
-    except ValueError:
-        # this can happen in python 3.5 when
-        # function has keyword-only arguments or annotations
+    if sys.version_info[:2] >= (3, 0):
+        # inspect has deprecated getargspec since version 3.0
         argspec = inspect.getfullargspec(f)
+    else:
+        try:
+            argspec = inspect.getargspec(f)
+        except ValueError:
+            # this can happen in python 3.5 when
+            # function has keyword-only arguments or annotations
+            argspec = inspect.getfullargspec(f)
     return argspec
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,11 +2,12 @@
 # vi:si:et:sw=4:sts=4:ts=4
 
 import random
+import sys
 import time
 
 from django.test import SimpleTestCase
 
-from memoize import Memoizer, function_namespace
+from memoize import Memoizer, function_namespace, _get_argspec
 
 
 class MemoizeTestCase(SimpleTestCase):
@@ -521,3 +522,15 @@ class MemoizeTestCase(SimpleTestCase):
 
         assert(a.foo(b) != result1)
         assert(a.foo(c) == result2)
+
+    def test_18_python3_uses_getfullargspec(self):
+        def foo():
+            return None
+
+        major_version = sys.version_info.major
+        argspec = _get_argspec(foo)
+
+        if major_version < 3:
+            assert argspec.__class__.__name__ is 'ArgSpec'
+        else:
+            assert argspec.__class__.__name__ is 'FullArgSpec'


### PR DESCRIPTION
Looks like getargspec has been deprecated for python versions >= 3.0. https://docs.python.org/3/library/inspect.html#inspect.getargspec This was throwing some warnings for me when writing unit tests for a project I'm working on. I figured I could silence the warnings or do this PR. Here ya go.