### PR TITLE
Fix error when the cached object is a numpy array

### DIFF
--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -350,7 +350,7 @@ class Memoizer(object):
                     )
                     return f(*args, **kwargs)
 
-                if rv == self.default_cache_value:
+                if isinstance(rv, DefaultCacheObject):
                     rv = f(*args, **kwargs)
                     try:
                         self.set(


### PR DESCRIPTION
When the cached value is a numpy array, statement: `if rv == self.default_cache_value:` causes `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`, because the result is not boolean, but a numpy array of booleans.